### PR TITLE
Wrap the hover content in a vscode MarkdownString

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -74,7 +74,8 @@ export async function activate(context: vscode.ExtensionContext) {
         const source =
           sourceUrl && `\n\nFurther reading: [${sourceUrl}](${sourceUrl})`;
         const entry = `${header}${text}${source}`;
-
+        const md = new vscode.MarkdownString(entry)
+        md.isTrusted = true;
         return new vscode.Hover(entry);
       }
 


### PR DESCRIPTION
...so that we can trust the content, which will let us do things like
run vscode commands in markdown "links":
https://code.visualstudio.com/api/references/vscode-api#MarkdownString