### PR TITLE
Format webview markdown with examples

### DIFF
--- a/src/concepts.ts
+++ b/src/concepts.ts
@@ -105,12 +105,14 @@ export class ConceptProvider implements vscode.TreeDataProvider<Concept> {
         map(
           ({
             title,
+            example,
             explanation: { text, sourceUrls } = {} as Record<string, any>
           }) => {
             const label = flow(replace(/`/g)(""), capitalize)(title);
-
             const { value: rawBlurb } = buildBlurb(title, text, sourceUrls);
-            const blurb = markdown.render(rawBlurb);
+            const rawBlurbWithExample = example ? `${rawBlurb}\n\n **Example:** ${example}\n` : rawBlurb;
+            const blurb = markdown.render(rawBlurbWithExample);
+
             return new Concept(label, blurb);
           }
         )

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -2,7 +2,7 @@ import { MarkdownString } from "vscode";
 
 export function buildBlurb(title = "", text = "", sourceUrls = []) {
   const header = title && `## 💡 ${title}\n`;
-  const sources = `\n\nMore info: ${sourceUrls
+  const sources = `\n\n **More info**: ${sourceUrls
     .map(url => `[${url}](${url})`)
     .join("\n")}`;
   const entry = `${header}${text}${sources}`;


### PR DESCRIPTION
The `example` field (if available) is now appended to the webview.