### PR TITLE
Reload concept not-graph on text document change

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -2,9 +2,11 @@ import { MarkdownString } from "vscode";
 
 export function buildBlurb(title = "", text = "", sourceUrls = []) {
   const header = title && `## 💡 ${title}\n`;
-  const sources = `\n\n **More info**: ${sourceUrls
+  const sources = sourceUrls.length > 0 ?
+    `\n\n **More info**: ${sourceUrls
     .map(url => `[${url}](${url})`)
-    .join("\n")}`;
+    .join("\n")}`
+    : '';
   const entry = `${header}${text}${sources}`;
   const markdown = new MarkdownString(entry);
 


### PR DESCRIPTION
Rather than loading up the list of concepts in the big-brain-time extension once when a file is opened, the order is reloaded whenever there's a change in the active TextDocument.

(note: we would probably want to debounce this ☝️ in a real system, but should be ok for demo-ing)